### PR TITLE
feat: Move cron schedule to config.json for external configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ cd random-notionify-slack
   "slack": {
     "botToken": "your_slack_bot_token",
     "channel": "your_channel"
-  }
+  },
+  "schedule": "0 8 * * *"
 }
 ```
 
-Replace `your_notion_api_key`, `your_database_id_A`, `your_database_id_B`, `your_slack_bot_token`, and `your_channel` with your actual Notion API key, database IDs, Slack bot token, and Slack channel.
+Replace `your_notion_api_key`, `your_database_id_A`, `your_database_id_B`, `your_slack_bot_token`, and `your_channel` with your actual Notion API key, database IDs, Slack bot token, and Slack channel.  
+The schedule field specifies the cron schedule.
 
 ## Usage
 
@@ -52,7 +54,7 @@ npm install
 node src/index.js
 ```
 
-This will start the application and schedule the task to run every day at 9 AM. You can modify the schedule by changing the cron schedule expression in `src/index.js`.
+This will start the application and schedule the task according to the cron schedule specified in `src/config.json`.
 
 ### Running with Docker
 
@@ -62,13 +64,13 @@ This will start the application and schedule the task to run every day at 9 AM. 
 docker compose up --build -d
 ```
 
-This will start the application and schedule the task to run every day at 9 AM. You can modify the schedule by changing the cron schedule expression in `src/index.js`.
+This will start the application and schedule the task according to the cron schedule specified in `src/config.json`.
 
 ## Project Structure
 
 - `src/index.js`: Main script that handles Notion page selection and Slack notification.
 - `src/blocks.js`: Contains the function to generate Slack message blocks.
-- `src/config.json`: Configuration file containing Notion API key, database IDs, and Slack bot token.
+- `src/config.json`: Configuration file containing Notion API key, database IDs, Slack bot token, and the cron schedule.
 
 ## License
 

--- a/src/config.json.example
+++ b/src/config.json.example
@@ -9,5 +9,6 @@
   "slack": {
     "botToken": "your_slack_bot_token",
     "channel": "your_channel"
-  }
+  },
+  "schedule": "0 8 * * *"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,9 @@ const databaseIds = config.notion.databaseIds;
 const slackClient = new WebClient(config.slack.botToken);
 const slackChannel = config.slack.channel;
 
+// Read the cron schedule from config
+const cronSchedule = config.schedule;
+
 /**
  * Fetches pages from the specified Notion database.
  * @param {string} databaseId - The ID of the Notion database.
@@ -115,7 +118,7 @@ const pickRandomPage = async () => {
     }
 };
 
-// Schedule the task to run every day at 8 AM
-cron.schedule('0 8 * * *', () => {
+// Schedule the task to run according to the cron schedule from config
+cron.schedule(cronSchedule, () => {
     pickRandomPage();
 });


### PR DESCRIPTION
- Added `schedule` field to `config.json` for setting cron schedule externally.
- Updated `index.js` to read the cron schedule from `config.json`.
- Updated `README.md` to reflect the new configuration method.